### PR TITLE
Add basic note model

### DIFF
--- a/backend/.irbrc
+++ b/backend/.irbrc
@@ -1,0 +1,2 @@
+require 'awesome_print'
+AwesomePrint.irb!

--- a/backend/.pryrc
+++ b/backend/.pryrc
@@ -1,0 +1,2 @@
+require 'awesome_print'
+AwesomePrint.pry!

--- a/backend/.rubocop.yml
+++ b/backend/.rubocop.yml
@@ -1,0 +1,29 @@
+# The behavior of RuboCop can be controlled via the .rubocop.yml
+# configuration file. It makes it possible to enable/disable
+# certain cops (checks) and to alter their behavior if they accept
+# any parameters. The file can be placed either in your home
+# directory or in some project directory.
+#
+# RuboCop will start looking for the configuration file in the directory
+# where the inspected file is and continue its way up to the root directory.
+#
+# See https://github.com/rubocop-hq/rubocop/blob/master/manual/configuration.md
+
+require: rubocop-rails
+
+AllCops:
+  Exclude:
+    - '.irbrc'
+    - '.pryrc'
+    - 'db/schema.rb'
+    - 'config/**/*'
+    - 'script/**/*'
+    - 'bin/**/*'
+  DisplayCopNames: true
+  TargetRubyVersion: 2.6
+
+Style/Documentation:
+  Enabled: false
+
+Metrics/LineLength:
+  Max: 100

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
@@ -5,27 +7,22 @@ ruby '2.6.5'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.2', '>= 6.0.2.1'
+
 # Use postgresql as the database for Active Record
 gem 'pg', '>= 0.18', '< 2.0'
-# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-# gem 'jbuilder', '~> 2.7'
+
 # Use Active Model has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
 
-group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-end
-
 group :development do
-  gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'awesome_print'
+  gem 'rubocop', require: false
+  gem 'rubocop-rails', require: false
+
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -56,8 +56,9 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2)
+    ast (2.4.0)
+    awesome_print (1.8.0)
     builder (3.2.4)
-    byebug (11.1.1)
     concurrent-ruby (1.1.6)
     crass (1.0.6)
     erubi (1.9.0)
@@ -66,6 +67,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
+    jaro_winkler (1.5.4)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -85,6 +87,9 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
+    parallel (1.18.0)
+    parser (2.6.5.0)
+      ast (~> 2.4.0)
     pg (1.2.2)
     rack (2.2.2)
     rack-test (1.1.0)
@@ -115,10 +120,22 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.20.3, < 2.0)
+    rainbow (3.0.0)
     rake (13.0.1)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    rubocop (0.76.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.6)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-rails (2.3.2)
+      rack (>= 1.1)
+      rubocop (>= 0.72.0)
+    ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
@@ -135,6 +152,7 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
+    unicode-display_width (1.6.0)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
@@ -144,13 +162,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  byebug
-  listen (>= 3.0.5, < 3.2)
+  awesome_print
   pg (>= 0.18, < 2.0)
   rails (~> 6.0.2, >= 6.0.2.1)
+  rubocop
+  rubocop-rails
   spring
   spring-watcher-listen (~> 2.0.0)
-  tzinfo-data
 
 RUBY VERSION
    ruby 2.6.5p114

--- a/backend/Rakefile
+++ b/backend/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 

--- a/backend/app/controllers/api/v1/notes_controller.rb
+++ b/backend/app/controllers/api/v1/notes_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Api
   module V1
     class NotesController < ApplicationController

--- a/backend/app/controllers/api/v1/notes_controller.rb
+++ b/backend/app/controllers/api/v1/notes_controller.rb
@@ -1,0 +1,11 @@
+module Api
+  module V1
+    class NotesController < ApplicationController
+      def index
+        notes = Note.order(:id)
+
+        render json: { notes: notes.map { |n| NotePresenter.new(n).to_json } }, status: :ok
+      end
+    end
+  end
+end

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::API
 end

--- a/backend/app/jobs/application_job.rb
+++ b/backend/app/jobs/application_job.rb
@@ -1,7 +1,0 @@
-class ApplicationJob < ActiveJob::Base
-  # Automatically retry jobs that encountered a deadlock
-  # retry_on ActiveRecord::Deadlocked
-
-  # Most jobs are safe to ignore if the underlying records are no longer available
-  # discard_on ActiveJob::DeserializationError
-end

--- a/backend/app/models/application_record.rb
+++ b/backend/app/models/application_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 end

--- a/backend/app/models/note.rb
+++ b/backend/app/models/note.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Note < ApplicationRecord
   validates :contents, presence: true
 end

--- a/backend/app/models/note.rb
+++ b/backend/app/models/note.rb
@@ -1,0 +1,3 @@
+class Note < ApplicationRecord
+  validates :contents, presence: true
+end

--- a/backend/app/presenters/note_presenter.rb
+++ b/backend/app/presenters/note_presenter.rb
@@ -1,0 +1,12 @@
+class NotePresenter
+  def initialize(note)
+    @note = note
+  end
+
+  def to_json
+    {
+      id: @note.id,
+      contents: @note.contents
+    }
+  end
+end

--- a/backend/app/presenters/note_presenter.rb
+++ b/backend/app/presenters/note_presenter.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 class NotePresenter
   def initialize(note)
     @note = note
   end
 
-  def to_json
+  def to_json(*_args)
     {
       id: @note.id,
       contents: @note.contents

--- a/backend/config.ru
+++ b/backend/config.ru
@@ -1,5 +1,0 @@
-# This file is used by Rack-based servers to start the application.
-
-require_relative 'config/environment'
-
-run Rails.application

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,3 +1,9 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+
+  namespace :api do
+    namespace :v1 do
+      post 'notes' => 'notes#index'
+    end
+  end
 end

--- a/backend/db/migrate/20200217184532_add_basic_note_structure.rb
+++ b/backend/db/migrate/20200217184532_add_basic_note_structure.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddBasicNoteStructure < ActiveRecord::Migration[6.0]
   def change
     create_table :notes do |t|

--- a/backend/db/migrate/20200217184532_add_basic_note_structure.rb
+++ b/backend/db/migrate/20200217184532_add_basic_note_structure.rb
@@ -1,0 +1,9 @@
+class AddBasicNoteStructure < ActiveRecord::Migration[6.0]
+  def change
+    create_table :notes do |t|
+      t.column :contents, :string, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -1,0 +1,24 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2020_02_17_184532) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "notes", force: :cascade do |t|
+    t.string "contents", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+end

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -1,6 +1,11 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
+# frozen_string_literal: true
+
+# This file should contain all the record creation needed to
+# seed the database with its default values.
+
+# The data can then be loaded with the rails db:seed command
+# (or created alongside the database with db:setup).
+
 # Examples:
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])


### PR DESCRIPTION
This adds a basic note structure with one field called `contents`. This is where the text will be saved. In a bigger application, these notes could be saved somewhere as files in the cloud, such as AWS. For now, this will suffice.

I also added an API so the client can retrieve the notes. There is no concept of user or authentication right now.